### PR TITLE
docs: document changelog policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog — Zombie Apocalypse
 
 All notable changes to **Zombie Apocalypse** are documented here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and release headings follow Semantic Versioning with an `Unreleased` section for
+work in progress.
 For the full commit history see the repository log.
 
 ## Unreleased

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ from spreading.
 Architecture Decision Documents (ADDs) capture significant design and technical decisions:
 
 - [docs/add/README.md](docs/add/README.md) — ADD index
+- [CHANGELOG.md](CHANGELOG.md) — release history and unreleased changes
 - [ADD-001: Godot 4 Migration](docs/add/add-001-godot4-migration.md)
 - [ADD-002: Generic Behaviour Scripts](docs/add/add-002-generic-behaviour-scripts.md)
 - [ADD-003: Multi-Character World Scene Design](docs/add/add-003-multi-character-design.md)


### PR DESCRIPTION
### Summary
- document the changelog format at the top of `CHANGELOG.md`
- link the changelog from the README documentation section

### Motivation
Issue #61 asks for the changelog policy to be made explicit and for the changelog to be easier to discover from the main docs list. The repo already had an `Unreleased` section, so this PR focuses on the missing policy/linking pieces.

### Validation
- `git diff --check`

Fixes #61